### PR TITLE
Add Jira-Database data pump

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 
 from github import GithubClient
-from jira import Jira
+from jira import JiraClient
 from testrail import TestRailClient
 from utils.constants import PROJECTS_ABBREV, REPORT_TYPES
 
@@ -54,8 +54,8 @@ def main():
         h.github_issue_regression(args.project)
         h = GithubClient()
     if args.report_type == 'jira-qa-requests':
-        h = Jira()
-        h.filters()
+        h = JiraClient()
+        h.jira_qa_requests()
 
 
 if __name__ == '__main__':

--- a/database.py
+++ b/database.py
@@ -35,10 +35,9 @@ class ReportGithubIssues(Base):
     __table__ = Table('report_github_issues', Base.metadata, autoload=True)
 
 
-'''
+
 class ReportJiraQARequests(Base):
     __table__ = Table('report_jira_qa_requests', Base.metadata, autoload=True) # noqa
-'''
 
 
 class Database:

--- a/database.py
+++ b/database.py
@@ -35,7 +35,6 @@ class ReportGithubIssues(Base):
     __table__ = Table('report_github_issues', Base.metadata, autoload=True)
 
 
-
 class ReportJiraQARequests(Base):
     __table__ = Table('report_jira_qa_requests', Base.metadata, autoload=True) # noqa
 

--- a/database.py
+++ b/database.py
@@ -35,6 +35,12 @@ class ReportGithubIssues(Base):
     __table__ = Table('report_github_issues', Base.metadata, autoload=True)
 
 
+'''
+class ReportJiraQARequests(Base):
+    __table__ = Table('report_jira_qa_requests', Base.metadata, autoload=True) # noqa
+'''
+
+
 class Database:
 
     def __init__(self):

--- a/jira.py
+++ b/jira.py
@@ -6,18 +6,18 @@ import pandas as pd
 from lib.jira_conn import JiraAPIClient
 from database import (
     Database,
-    # ReportJiraQARequests
+    ReportJiraQARequests
 )
 from utils.datetime_utils import DatetimeUtils as dt
+from utils.constants import FILTER_ID_ALL_REQUESTS_2022, MAX_RESULT
+
 
 # JQL query All QA Requests since 2022 filter_id: 13856
-FILTER_ID_ALL_REQUESTS_2022 = "13856"
-# Fields needed
+# Extra fields needed
 STORY_POINTS = "customfield_10037"
 FIREFOX_RELEASE_TRAIN = "customfield_10155"
 ENGINEERING_TEAM = "customfield_10134"
 DEFAULT_COLUMNS = "id,key,status,created,summary,labels,assignee,"
-MAX_RESULT = "maxResults=100"
 
 JQL_QUERY = 'jql=filter='
 

--- a/jira.py
+++ b/jira.py
@@ -51,7 +51,28 @@ class JiraClient(Jira):
         self.db = DatabaseJira()
 
     def jira_qa_requests(self):
-        payload = self.filters()
+        # payload = self.filters()
+
+        payload = [{
+            "key": "QA-2503",
+            "fields": {
+                "summary": "QA for password generator Android",
+                "created": "2024-07-08 10:00:00",
+                "assignee": "None",
+                "customfield_10155": {
+                    "value": "Fx129"
+                },
+                "customfield_10134": {
+                    "value": "Mobile Android"
+                },
+                "customfield_10037": "2",
+                "status": {
+                    "name": "Created"
+                },
+                "labels": [
+                ]
+            }
+        }]
 
         data_frame = self.db.report_jira_qa_requests_payload(payload)
         print(data_frame)
@@ -108,10 +129,12 @@ class DatabaseJira(Database):
 
     def report_jira_qa_requests_insert(self, payload):
         print(payload)
-        for index, row in payload.iterrows():
 
+        for index, row in payload.iterrows():
+            print(row)
             report = ReportJiraQARequests(jira_key=row['jira_key'],
                                           jira_created_at=row['jira_created_at'], # noqa
+                                          jira_summary=row['jira_summary'], # noqa
                                           jira_firefox_release_train=row['jira_firefox_release_train'], # noqa
                                           jira_engineering_team=row['jira_engineering_team'], # noqa
                                           jira_story_points=row['jira_story_points'], # noqa

--- a/jira.py
+++ b/jira.py
@@ -115,5 +115,5 @@ class DatabaseJira(Database):
         # This is the only way working locally to insert data
         # payload.to_sql('report_jira_qa_requests', con=engine, if_exists='append', index=False) # noqa
 
-        # session.add(report)
-        # session.commit()
+        session.add(report)
+        session.commit()

--- a/jira.py
+++ b/jira.py
@@ -26,6 +26,7 @@ class Jira:
 
     def __init__(self):
         try:
+
             JIRA_HOST = os.environ['JIRA_HOST']
             self.client = JiraAPIClient(JIRA_HOST)
             self.client.user = os.environ['JIRA_USER']
@@ -51,13 +52,16 @@ class JiraClient(Jira):
         self.db = DatabaseJira()
 
     def jira_qa_requests(self):
-        # payload = self.filters()
-
+        payload = self.filters()
+        print("This is the payload returning from filter")
+        print(payload)
+        '''
+        Working Test Payload
         payload = [{
-            "key": "QA-2503",
+            "key": "QA-2555",
             "fields": {
-                "summary": "QA for password generator Android",
-                "created": "2024-07-08 10:00:00",
+                "summary": "[QA for] password generator Android",
+                "created": "2024-07-01T19:00:26.017-0400",
                 "assignee": "None",
                 "customfield_10155": {
                     "value": "Fx129"
@@ -71,8 +75,42 @@ class JiraClient(Jira):
                 },
                 "labels": [
                 ]
-            }
-        }]
+            }},{
+            "key": "QA-2555",
+            "fields": {
+                "summary": "[QA for] password generator Android",
+                "created": "2024-08-01T19:00:26.017-0400",
+                "assignee": {
+                    "self": "https://mozilla-hub.atlassian.net/rest/api/2/user?accountId=712020%3A94a51a44-b5cc-4200-b015-b3344f6829a7",
+                    "accountId": "712020:94a51a44-b5cc-4200-b015-b3344f6829a7",
+                    "emailAddress": "dbarladeanu@mozilla.com",
+                    "avatarUrls": {
+                        "48x48": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/48",
+                        "24x24": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/24",
+                        "16x16": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/16",
+                        "32x32": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/32"
+                    },
+                    "displayName": "Diana Andreea Barladeanu",
+                    "active": True,
+                    "timeZone": "America/Indiana/Indianapolis",
+                    "accountType": "atlassian"
+                },
+                "customfield_10155": {
+                    "value": "Fx129"
+                },
+                "customfield_10134": {
+                    "value": "Mobile Android"
+                },
+                "customfield_10037": None,
+                "status": {
+                    "name": "CI/Execution"
+                },
+                "labels": [
+                    ]
+                }
+                }
+        ]
+        '''
 
         data_frame = self.db.report_jira_qa_requests_payload(payload)
         print(data_frame)
@@ -120,7 +158,7 @@ class DatabaseJira(Database):
         # Rename columns
         df_selected = df_selected.rename(columns=selected_columns)
 
-        #df_selected['jira_created_at'] = df_selected['jira_created_at'].apply(dt.convert_to_utc) # noqa
+        df_selected['jira_created_at'] = df_selected['jira_created_at'].apply(dt.convert_to_utc) # noqa
 
         # Join list of labels into a single string
         df_selected['jira_labels'] = df_selected['jira_labels'].apply(lambda x: ','.join(x) if isinstance(x, list) else x) # noqa
@@ -133,7 +171,7 @@ class DatabaseJira(Database):
         for index, row in payload.iterrows():
             print(row)
             report = ReportJiraQARequests(jira_key=row['jira_key'],
-                                          jira_created_at=row['jira_created_at'], # noqa
+                                          jira_created_at=row['jira_created_at'].date(), # noqa
                                           jira_summary=row['jira_summary'], # noqa
                                           jira_firefox_release_train=row['jira_firefox_release_train'], # noqa
                                           jira_engineering_team=row['jira_engineering_team'], # noqa
@@ -144,6 +182,5 @@ class DatabaseJira(Database):
 
         # This is the only way working locally to insert data
         # payload.to_sql('report_jira_qa_requests', con=engine, if_exists='append', index=False) # noqa
-
         self.session.add(report)
         self.session.commit()

--- a/jira.py
+++ b/jira.py
@@ -107,10 +107,17 @@ class DatabaseJira(Database):
         return df_selected
 
     def report_jira_qa_requests_insert(self, payload):
-        pass
-        # TBD
-        # This is the way used in testrail.py
-        report = ReportJiraQARequests()
+        print(payload)
+        for index, row in payload.iterrows():
+
+            report = ReportJiraQARequests(jira_key=row['jira_key'],
+                                          jira_created_at=row['jira_created_at'], # noqa
+                                          jira_firefox_release_train=row['jira_firefox_release_train'], # noqa
+                                          jira_engineering_team=row['jira_engineering_team'], # noqa
+                                          jira_story_points=row['jira_story_points'], # noqa
+                                          jira_status=row['jira_status'], # noqa
+                                          jira_assignee_username=row['jira_assignee_username'], # noqa
+                                          jira_labels=row['jira_labels'])
 
         # This is the only way working locally to insert data
         # payload.to_sql('report_jira_qa_requests', con=engine, if_exists='append', index=False) # noqa

--- a/jira.py
+++ b/jira.py
@@ -81,14 +81,14 @@ class JiraClient(Jira):
                 "summary": "[QA for] password generator Android",
                 "created": "2024-08-01T19:00:26.017-0400",
                 "assignee": {
-                    "self": "https://mozilla-hub.atlassian.net/rest/api/2/user?accountId=712020%3A94a51a44-b5cc-4200-b015-b3344f6829a7",
+                    "self": "https://mozilla-hub.atlassian.net/rest/api/2/user?accountId=712020%3A94a51a44-b5cc-4200-b015-b3344f6829a7", # noqa
                     "accountId": "712020:94a51a44-b5cc-4200-b015-b3344f6829a7",
                     "emailAddress": "dbarladeanu@mozilla.com",
                     "avatarUrls": {
-                        "48x48": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/48",
-                        "24x24": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/24",
-                        "16x16": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/16",
-                        "32x32": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/32"
+                        "48x48": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/48", # noqa
+                        "24x24": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/24", # noqa
+                        "16x16": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/16", # noqa
+                        "32x32": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/32"  # noqa
                     },
                     "displayName": "Diana Andreea Barladeanu",
                     "active": True,
@@ -111,6 +111,7 @@ class JiraClient(Jira):
                 }
         ]
         '''
+        self.db.qa_requests_delete()
 
         data_frame = self.db.report_jira_qa_requests_payload(payload)
         print(data_frame)
@@ -123,6 +124,12 @@ class DatabaseJira(Database):
     def __init__(self):
         super().__init__()
         self.db = Database()
+
+    def qa_requests_delete(self):
+        """ Wipe out all test suite data.
+        NOTE: we'll renew this data from Testrail every session."""
+        self.session.query(ReportJiraQARequests).delete()
+        self.session.commit()
 
     def report_jira_qa_requests_payload(self, payload):
         # Normalize the JSON data

--- a/jira.py
+++ b/jira.py
@@ -1,8 +1,14 @@
 import os
 import sys
 
-from lib.jira_conn import JiraAPIClient
+import pandas as pd
 
+from lib.jira_conn import JiraAPIClient
+from database import (
+    Database,
+    # ReportJiraQARequests
+)
+from utils.datetime_utils import DatetimeUtils as dt
 
 # JQL query All QA Requests since 2022 filter_id: 13856
 FILTER_ID_ALL_REQUESTS_2022 = "13856"
@@ -32,6 +38,82 @@ class Jira:
     # API: Filters
     def filters(self):
         query = JQL_QUERY + FILTER_ID_ALL_REQUESTS_2022 + '&fields=' \
-                + DEFAULT_COLUMNS + STORY_POINTS + FIREFOX_RELEASE_TRAIN \
+                + DEFAULT_COLUMNS + ',' + STORY_POINTS + ',' \
+                + FIREFOX_RELEASE_TRAIN + ',' \
                 + ENGINEERING_TEAM + '&' + MAX_RESULT
+
         return self.client.get_search(query)
+
+
+class JiraClient(Jira):
+    def __init__(self):
+        super().__init__()
+        self.db = DatabaseJira()
+
+    def jira_qa_requests(self):
+        payload = self.filters()
+
+        data_frame = self.db.report_jira_qa_requests_payload(payload)
+        print(data_frame)
+
+        self.db.report_jira_qa_requests_insert(data_frame)
+
+
+class DatabaseJira(Database):
+
+    def __init__(self):
+        super().__init__()
+        self.db = Database()
+
+    def report_jira_qa_requests_payload(self, payload):
+        # Normalize the JSON data
+        df = pd.json_normalize(payload, sep='_')
+
+        # Check if 'jira_assignee_username' exists
+        # if not use 'alternative_assignee_emailAddress'
+        if 'fields_assignee_emailAddress' not in df.columns:
+            df['fields_assignee_emailAddress'] = df.get('fields_assignee', "None") # noqa
+        else:
+            df['fields_assignee_emailAddress'] = df['fields_assignee_emailAddress'].fillna("Not Assigned") # noqa
+
+        # Drop the alternative column if it exists
+        if 'fields_assignee' in df.columns:
+            df.drop(columns=['fields_assignee'], inplace=True)
+
+        # Select specific columns
+        selected_columns = {
+            'key': 'jira_key',
+            'fields_summary': 'jira_summary',
+            'fields_created': 'jira_created_at',
+            'fields_customfield_10155_value': 'jira_firefox_release_train',
+            'fields_customfield_10134_value': 'jira_engineering_team',
+            'fields_customfield_10037': 'jira_story_points',
+            'fields_status_name': 'jira_status',
+            'fields_assignee_emailAddress': 'jira_assignee_username',
+            'fields_labels': 'jira_labels'
+        }
+
+        # Select specific columns
+        df_selected = df[selected_columns.keys()]
+
+        # Rename columns
+        df_selected = df_selected.rename(columns=selected_columns)
+
+        df_selected['jira_created_at'] = df_selected['jira_created_at'].apply(dt.convert_to_utc) # noqa
+
+        # Join list of labels into a single string
+        df_selected['jira_labels'] = df_selected['jira_labels'].apply(lambda x: ','.join(x) if isinstance(x, list) else x) # noqa
+
+        return df_selected
+
+    def report_jira_qa_requests_insert(self, payload):
+        pass
+        # TBD
+        # This is the way used in testrail.py
+        # report = ReportJiraQARequests(payload)
+
+        # This is the only way working locally to insert data
+        # payload.to_sql('report_jira_qa_requests', con=engine, if_exists='append', index=False) # noqa
+
+        # session.add(report)
+        # session.commit()

--- a/jira.py
+++ b/jira.py
@@ -110,7 +110,7 @@ class DatabaseJira(Database):
         pass
         # TBD
         # This is the way used in testrail.py
-        # report = ReportJiraQARequests(payload)
+        report = ReportJiraQARequests(payload)
 
         # This is the only way working locally to insert data
         # payload.to_sql('report_jira_qa_requests', con=engine, if_exists='append', index=False) # noqa

--- a/jira.py
+++ b/jira.py
@@ -120,7 +120,7 @@ class DatabaseJira(Database):
         # Rename columns
         df_selected = df_selected.rename(columns=selected_columns)
 
-        df_selected['jira_created_at'] = df_selected['jira_created_at'].apply(dt.convert_to_utc) # noqa
+        #df_selected['jira_created_at'] = df_selected['jira_created_at'].apply(dt.convert_to_utc) # noqa
 
         # Join list of labels into a single string
         df_selected['jira_labels'] = df_selected['jira_labels'].apply(lambda x: ','.join(x) if isinstance(x, list) else x) # noqa

--- a/jira.py
+++ b/jira.py
@@ -26,7 +26,6 @@ class Jira:
 
     def __init__(self):
         try:
-
             JIRA_HOST = os.environ['JIRA_HOST']
             self.client = JiraAPIClient(JIRA_HOST)
             self.client.user = os.environ['JIRA_USER']
@@ -55,62 +54,7 @@ class JiraClient(Jira):
         payload = self.filters()
         print("This is the payload returning from filter")
         print(payload)
-        '''
-        Working Test Payload
-        payload = [{
-            "key": "QA-2555",
-            "fields": {
-                "summary": "[QA for] password generator Android",
-                "created": "2024-07-01T19:00:26.017-0400",
-                "assignee": "None",
-                "customfield_10155": {
-                    "value": "Fx129"
-                },
-                "customfield_10134": {
-                    "value": "Mobile Android"
-                },
-                "customfield_10037": "2",
-                "status": {
-                    "name": "Created"
-                },
-                "labels": [
-                ]
-            }},{
-            "key": "QA-2555",
-            "fields": {
-                "summary": "[QA for] password generator Android",
-                "created": "2024-08-01T19:00:26.017-0400",
-                "assignee": {
-                    "self": "https://mozilla-hub.atlassian.net/rest/api/2/user?accountId=712020%3A94a51a44-b5cc-4200-b015-b3344f6829a7", # noqa
-                    "accountId": "712020:94a51a44-b5cc-4200-b015-b3344f6829a7",
-                    "emailAddress": "dbarladeanu@mozilla.com",
-                    "avatarUrls": {
-                        "48x48": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/48", # noqa
-                        "24x24": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/24", # noqa
-                        "16x16": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/16", # noqa
-                        "32x32": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:94a51a44-b5cc-4200-b015-b3344f6829a7/744bb20e-d66a-475a-839a-765800c8cfda/32"  # noqa
-                    },
-                    "displayName": "Diana Andreea Barladeanu",
-                    "active": True,
-                    "timeZone": "America/Indiana/Indianapolis",
-                    "accountType": "atlassian"
-                },
-                "customfield_10155": {
-                    "value": "Fx129"
-                },
-                "customfield_10134": {
-                    "value": "Mobile Android"
-                },
-                "customfield_10037": None,
-                "status": {
-                    "name": "CI/Execution"
-                },
-                "labels": [
-                    ]
-                }
-                }
-        ]
-        '''
+
         self.db.qa_requests_delete()
 
         data_frame = self.db.report_jira_qa_requests_payload(payload)
@@ -128,6 +72,7 @@ class DatabaseJira(Database):
     def qa_requests_delete(self):
         """ Wipe out all test suite data.
         NOTE: we'll renew this data from Testrail every session."""
+        print("Delete entries from db first")
         self.session.query(ReportJiraQARequests).delete()
         self.session.commit()
 
@@ -170,6 +115,9 @@ class DatabaseJira(Database):
         # Join list of labels into a single string
         df_selected['jira_labels'] = df_selected['jira_labels'].apply(lambda x: ','.join(x) if isinstance(x, list) else x) # noqa
 
+        # Convert NaN values to 0 and ensure the column is of type int
+        df_selected['jira_story_points'] = df_selected['jira_story_points'].fillna(0).astype(int) # noqa
+
         return df_selected
 
     def report_jira_qa_requests_insert(self, payload):
@@ -186,8 +134,5 @@ class DatabaseJira(Database):
                                           jira_status=row['jira_status'], # noqa
                                           jira_assignee_username=row['jira_assignee_username'], # noqa
                                           jira_labels=row['jira_labels'])
-
-        # This is the only way working locally to insert data
-        # payload.to_sql('report_jira_qa_requests', con=engine, if_exists='append', index=False) # noqa
-        self.session.add(report)
+            self.session.add(report)
         self.session.commit()

--- a/jira.py
+++ b/jira.py
@@ -110,7 +110,7 @@ class DatabaseJira(Database):
         pass
         # TBD
         # This is the way used in testrail.py
-        report = ReportJiraQARequests(payload)
+        report = ReportJiraQARequests()
 
         # This is the only way working locally to insert data
         # payload.to_sql('report_jira_qa_requests', con=engine, if_exists='append', index=False) # noqa

--- a/jira.py
+++ b/jira.py
@@ -115,5 +115,5 @@ class DatabaseJira(Database):
         # This is the only way working locally to insert data
         # payload.to_sql('report_jira_qa_requests', con=engine, if_exists='append', index=False) # noqa
 
-        session.add(report)
-        session.commit()
+        self.session.add(report)
+        self.session.commit()

--- a/lib/jira_conn.py
+++ b/lib/jira_conn.py
@@ -37,32 +37,35 @@ class JiraAPIClient:
 
         # Store all results
         all_results = []
+        params = {}
 
         headers = {"Content-Type": "application/json"}
 
         # Pagination variables
-        start_at = 0
         max_results = 100
-        total = 1  # Initial value greater than start_at to enter the loop
+        total = None
+        params['startAt'] = 0
 
-        while start_at < total:
+        while True:
             # Send GET request
             response = requests.get(
                         url,
                         headers=headers,
-                        auth=HTTPBasicAuth(self.user, self.password))
+                        auth=HTTPBasicAuth(self.user, self.password),
+                        params=params)
 
-            if response.status_code == 200:
-                data = response.json()
-                all_results.extend(data['issues'])
-                total = data['total']  # Update total based on the response
-                start_at += max_results  # Move to the next page
-            else:
-                print(f"Failed to fetch data: {response.status_code}")
-                print(response.text)
+            data = response.json()
+            all_results.extend(data['issues'])
+            if total is None:
+                total = data['total']
+
+            # Increment the startAt parameter
+            params['startAt'] += max_results
+
+            # Check if we've retrieved all results
+            if params['startAt'] >= total:
                 break
 
         # Print the total number of issues retrieved
         print(f"Total issues retrieved: {len(all_results)}")
-        print(data)
-        return data
+        return all_results

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -13,3 +13,7 @@ REPORT_TYPES = [
     'issue-regression',
     'jira-qa-requests'
 ]
+
+# JQL query All QA Requests since 2022 filter_id: 13856
+FILTER_ID_ALL_REQUESTS_2022 = "13856"
+MAX_RESULT = "maxResults=100"

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -1,3 +1,5 @@
+import pytz
+
 from datetime import datetime, timedelta
 
 
@@ -15,6 +17,11 @@ class DatetimeUtils:
     def convert_epoch_to_datetime(int_epoch_date):
         ts = datetime.fromtimestamp(int_epoch_date)
         return ts.strftime(format_date)
+
+    def convert_to_utc(datetime_str):
+        """Convert datetime string with timezone offset to UTC."""
+        dt = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%f%z")
+        return dt.astimezone(pytz.UTC)
 
     def start_date(num_days, end_date=''):
         """ given num_days, calculate a start_date


### PR DESCRIPTION
This PR is a follow up of #34 to add the pieces needed to connect Jira module with Database.

- JiraClient class
Calls the methods to get the data from Jira API and to insert data in the database
- DatabaseJira class
Uses pandas to format the data so that it can be inserted in the database.

This is an example of a dataframe

![imagen](https://github.com/mozilla-mobile/test-dashboard/assets/1897507/54e9088b-205e-4656-8e0b-dff8a07f25b3)

I have tested that I can inject that dataframe into the `report_jira_qa_requests` table