### PR TITLE
Update get requests to new API version - after migration

### DIFF
--- a/.github/workflows/staging-push.yml
+++ b/.github/workflows/staging-push.yml
@@ -40,7 +40,7 @@ jobs:
             echo "CLOUD_SQL_DATABASE_PASSWORD=${{ secrets.CLOUD_SQL_DATABASE_PASSWORD }}" >> $GITHUB_ENV
             echo "CLOUD_SQL_DATABASE_NAME=staging" >> $GITHUB_ENV
             echo "CLOUD_SQL_DATABASE_PORT=${{ secrets.CLOUD_SQL_DATABASE_PORT }}" >> $GITHUB_ENV
-            echo "TESTRAIL_HOST=${{ secrets.TESTRAIL_HOST_TEST }}" >> $GITHUB_ENV
+            echo "TESTRAIL_HOST=${{ secrets.TESTRAIL_HOST }}" >> $GITHUB_ENV
             echo "TESTRAIL_USERNAME=${{ secrets.TESTRAIL_USERNAME }}" >> $GITHUB_ENV
             echo "TESTRAIL_PASSWORD=${{ secrets.TESTRAIL_PASSWORD }}" >> $GITHUB_ENV
             echo "JIRA_HOST=${{ secrets.JIRA_HOST }}" >> $GITHUB_ENV
@@ -48,14 +48,14 @@ jobs:
             echo "JIRA_PASSWORD=${{ secrets.JIRA_PASSWORD }}" >> $GITHUB_ENV
             echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
 
-      #- name: Update DB - test runs 
-      #  run: python ./__main__.py --report-type test-run-counts --project fenix --start-date 2021-08-15 --end-date 2021-10-01 
+      - name: Update DB - test runs
+        run: python ./__main__.py --report-type test-case-coverage --project ALL
 
-      - name: Jira query qa-requests
-        run: python ./__main__.py --report-type jira-qa-requests
-      - name: Jira query qa-needed
-        if: always()
-        run: python ./__main__.py --report-type jira-qa-needed
+      #- name: Jira query qa-requests
+      #  run: python ./__main__.py --report-type jira-qa-requests
+      #- name: Jira query qa-needed
+      #  if: always()
+      #  run: python ./__main__.py --report-type jira-qa-needed
       - name: Set job log URL
         if: always()
         run: echo "JOB_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV

--- a/lib/testrail_conn.py
+++ b/lib/testrail_conn.py
@@ -75,8 +75,30 @@ class APIClient:
                 payload = bytes(json.dumps(data), 'utf-8')
                 response = requests.post(url, headers=headers, data=payload)
         else:
+            all_items = []
+            offset = 0
+            limit = 250
+
             headers['Content-Type'] = 'application/json'
-            response = requests.get(url, headers=headers)
+
+            while True:
+                response = requests.get(f"{url}&limit={limit}&offset={offset}", headers=headers)
+                data = response.json()
+
+                # Check if 'cases' key exists in the response
+                if 'cases' in data:
+                    all_items.extend(data['cases'])
+
+                    # Break if fewer items are returned than the limit, indicating the last page
+                    if len(data['cases']) < limit:
+                        break
+                else:
+                    all_items = data
+                    break  # If 'cases' key is not present, exit the loop
+
+                offset += limit
+
+            return all_items
 
         if response.status_code > 201:
             try:

--- a/testrail.py
+++ b/testrail.py
@@ -102,7 +102,6 @@ class TestRailClient(TestRail):
 
             testrail_project_id = project_ids[1]
             suites = self.test_suites(testrail_project_id)
-
             for suite in suites:
                 """
                 print("testrail_project_id: {0}".format(testrail_project_id))
@@ -150,10 +149,10 @@ class TestRailClient(TestRail):
                                  testrail_project_id, test_suite_id):
 
         # Pull JSON blob from Testrail
-        cases_metadata = self.test_cases(testrail_project_id, test_suite_id)
+        cases = self.test_cases(testrail_project_id, test_suite_id)
 
         # Format and store data in a data payload array
-        payload = self.db.report_test_coverage_payload(cases_metadata)
+        payload = self.db.report_test_coverage_payload(cases)
         print(payload)
 
         # Insert data in 'totals' array into DB
@@ -203,11 +202,10 @@ class DatabaseTestRail(Database):
         self.session.add(suites)
         self.session.commit()
 
-    def report_test_coverage_payload(self, cases_metadata):
+    def report_test_coverage_payload(self, cases):
         """given testrail data (cases), calculate test case counts by type"""
 
         payload = []
-        cases = cases_metadata['cases']
 
         for case in cases:
 


### PR DESCRIPTION
The new API version has set a limit of 250 for bulk requests. 
For test cases we have more than that, so we need to iterate to get all results.