### PR TITLE
Add experimenter project to available projects to query.

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -4,6 +4,7 @@ PROJECTS_ABBREV = [
     'reference-browser',
     'firefox-ios',
     'focus-ios',
+    'experimenter',
     'ALL',
 ]
 


### PR DESCRIPTION
This adds the experimenter project to the available projects the script can query. I have made the needed changes within the testrail project for this to work. 

There will be some changes potentially needed within the database. I had to change `test_suite_name` to 200 characters from 150. This is because some of the test suite names are long depending on the experiment tested. 

Also, the API number for experimenter is `54`. Here is how I changed the sample SQL file to account for the changes needed for experimenter.

`+INSERT INTO projects VALUES (1,59,'fenix','Fenix Browser'),(2,48,'focus-android','Focus for Android'),(3,14,'firefox-ios','Firefox for iOS'),(4,27,'focus-ios','Focus for iOS'),(5,58,'reference-browser','Reference Browser'),(6,54,'experimenter','Experimenter');/*!40000 ALTER TABLE `projects` ENABLE KEYS */;`

`+  test_suite_name varchar(200) DEFAULT NULL,`